### PR TITLE
feat: Add GitHub Actions for automated plan generation

### DIFF
--- a/.github/workflows/automated_planner.yml
+++ b/.github/workflows/automated_planner.yml
@@ -1,0 +1,56 @@
+name: Automated AI Planner Jobs
+
+on:
+  schedule:
+    # Run the new plan job at a random time between 12:00 AM and 12:59 AM on the 1st of every month
+    - cron: '0 0 1 * *'
+    # Run the revision job at a random time between 12:00 PM and 12:59 PM every Sunday
+    - cron: '0 12 * * 0'
+  workflow_dispatch:
+
+jobs:
+  new_plan:
+    if: github.event.schedule == '0 0 1 * *'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run new plan job
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_ASSISTANT_ID: ${{ secrets.OPENAI_ASSISTANT_ID }}
+        run: python run_jobs.py new_plan
+
+  revision:
+    if: github.event.schedule == '0 12 * * 0'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run revision job
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_ASSISTANT_ID: ${{ secrets.OPENAI_ASSISTANT_ID }}
+        run: python run_jobs.py revision

--- a/README.md
+++ b/README.md
@@ -17,3 +17,18 @@ A simple Streamlit app template for you to modify!
    ```
    $ streamlit run streamlit_app.py
    ```
+
+### Automated Jobs (GitHub Actions)
+
+This repository uses GitHub Actions to run automated jobs for generating and revising plans. The workflows are defined in `.github/workflows/automated_planner.yml`.
+
+For the automated jobs to run successfully, you must configure the following secrets in your GitHub repository's settings (`Settings > Secrets and variables > Actions`):
+
+- `SUPABASE_URL`: Your Supabase project URL.
+- `SUPABASE_ANON_KEY`: Your Supabase anonymous key.
+- `OPENAI_API_KEY`: Your OpenAI API key.
+- `OPENAI_ASSISTANT_ID`: Your OpenAI Assistant ID.
+
+The jobs are scheduled as follows:
+- **New Plan Generation**: Runs at 12:00 AM on the 1st of every month.
+- **Plan Revision**: Runs at 12:00 PM every Sunday.

--- a/run_jobs.py
+++ b/run_jobs.py
@@ -1,0 +1,110 @@
+import argparse
+import logging
+from datetime import datetime
+from backend import Config, DataService, EnhancedAIServiceSync
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+def _process_mr_plan(ai_service, data_service, mr, month, year, action, tier_mix='balanced'):
+    """Helper function to process a plan for a single MR."""
+    try:
+        mr_name = mr['name']
+        logger.info(f"Processing {action} for {mr_name} for {month}/{year}")
+        customers = data_service.get_customer_data(mr_name)
+        if not customers:
+            logger.warning(f"No customers found for {mr_name}, skipping.")
+            return
+
+        plan_result = ai_service.generate_monthly_plan_with_clustering(
+            mr_name, month, year, customers, action, tier_mix,
+            data_service, enable_clustering=True
+        )
+
+        thread_id = plan_result.get('thread_id')
+        clustering_metadata = plan_result.get('clustering_metadata', {})
+        clean_plan_result = {k: v for k, v in plan_result.items()
+                               if k not in ['thread_id', 'clustering_metadata']}
+
+        plan_data = {
+            'mr_name': mr_name,
+            'plan_month': month,
+            'plan_year': year,
+            'original_plan_json': clean_plan_result,
+            'current_plan_json': clean_plan_result,
+            'current_revision': 0 if action == 'NEW_PLAN' else 1,
+            'status': 'ACTIVE',
+            'created_at': datetime.now().isoformat(),
+            'updated_at': datetime.now().isoformat(),
+            'total_customers': len(customers),
+            'total_planned_visits': clean_plan_result['executive_summary']['planned_total_visits'],
+            'total_revenue_target': clean_plan_result['executive_summary']['expected_revenue'],
+            'generation_method': f'ai_enhanced_clustering_v3_{tier_mix}',
+            'data_quality_score': 0.99,
+            'thread_id': thread_id
+        }
+
+        data_service.save_monthly_plan(plan_data)
+        logger.info(f"Successfully processed and saved {action} for {mr_name}")
+
+    except Exception as e:
+        logger.error(f"Error processing {action} for {mr['name']}: {e}")
+
+def run_new_plan_job():
+    """Job to create new plans for MRs without a plan for the current month."""
+    logger.info("Running new plan job...")
+    try:
+        config = Config()
+        data_service = DataService(config)
+        ai_service = EnhancedAIServiceSync(config)
+
+        now = datetime.now()
+        month, year = now.month, now.year
+
+        all_mrs = data_service.get_medical_representatives()
+        mrs_with_plans = data_service.get_mrs_with_plans(month, year)
+        mrs_with_plans_names = {mr['name'] for mr in mrs_with_plans}
+
+        mrs_to_plan = [mr for mr in all_mrs if mr['name'] not in mrs_with_plans_names]
+
+        logger.info(f"Found {len(mrs_to_plan)} MRs for new plan generation.")
+
+        for mr in mrs_to_plan:
+            _process_mr_plan(ai_service, data_service, mr, month, year, 'NEW_PLAN')
+
+    except Exception as e:
+        logger.error(f"New plan job failed: {e}")
+    logger.info("New plan job finished.")
+
+def run_revision_job():
+    """Job to create revisions for MRs with an existing plan for the current month."""
+    logger.info("Running revision job...")
+    try:
+        config = Config()
+        data_service = DataService(config)
+        ai_service = EnhancedAIServiceSync(config)
+
+        now = datetime.now()
+        month, year = now.month, now.year
+
+        mrs_to_revise = data_service.get_mrs_with_plans(month, year)
+        logger.info(f"Found {len(mrs_to_revise)} MRs for revision.")
+
+        for mr in mrs_to_revise:
+            _process_mr_plan(ai_service, data_service, mr, month, year, 'REVISION')
+
+    except Exception as e:
+        logger.error(f"Revision job failed: {e}")
+    logger.info("Revision job finished.")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run automated planner jobs.")
+    parser.add_argument("job_type", choices=["new_plan", "revision"], help="The type of job to run.")
+
+    args = parser.parse_args()
+
+    if args.job_type == "new_plan":
+        run_new_plan_job()
+    elif args.job_type == "revision":
+        run_revision_job()


### PR DESCRIPTION
This commit introduces automated plan generation and revision using GitHub Actions. This approach replaces the previous in-app scheduler to ensure that the jobs run reliably, even if the Streamlit application server is offline.

A new script, `run_jobs.py`, has been created to be executed by the workflow. It can be called with arguments to run either the "new plan" or "revision" job.

A GitHub Actions workflow is defined in `.github/workflows/automated_planner.yml` with two scheduled jobs:
1.  **New Plan Generation**: Runs on the 1st of every month.
2.  **Plan Revision**: Runs every Sunday.

The README has been updated with instructions on how to configure the necessary secrets in the GitHub repository for the actions to function.